### PR TITLE
Remove need for global calls in hook files

### DIFF
--- a/src/zoning/hooks/__init__.py
+++ b/src/zoning/hooks/__init__.py
@@ -30,13 +30,12 @@ def runHook (slug, hook, data):
         print(f'No hook file found for slug {slug} - not {action} data')
         return data
     else:
-        hooks = {}
+        local_env = {}
         with open(hookFile) as hookRaw:
-            gl = {k: v for k, v in globals().items()}
-            exec(hookRaw.read(), gl, hooks)
-        if not hook in hooks:
+            exec(hookRaw.read(), local_env, local_env)
+        if not hook in local_env:
             print(f'No {hook} hook found for slug {slug} - not {action} data')
             return data
         else:
             print(f'Executing {hook} hook for slug {slug}')
-            return hooks[hook](data, datadir)
+            return local_env[hook](data, datadir)

--- a/src/zoning/hooks/sacramento.py
+++ b/src/zoning/hooks/sacramento.py
@@ -11,8 +11,6 @@ from src.zoning.zoneingest import FOOT_TO_METER, ACRE_TO_HECTARE
 from src.ingest.shputils import readZippedShapefile, fastOverlay
 
 def after (data, datadir):
-    global join, readZippedShapefile, fastOverlay, ptg, Point, gp, pd, FOOT_TO_METER, ACRE_TO_HECTARE, np
-
     print('reprojecting data')
     data = data.to_crs(epsg=26942)
 

--- a/src/zoning/hooks/sanfrancisco.py
+++ b/src/zoning/hooks/sanfrancisco.py
@@ -14,7 +14,6 @@ from functools import partial
 
 # Unify several datasets to produce a canonical SF Zoning dataset
 def before (data, datadir):
-    global readZippedShapefile, join, gp, exists, fastOverlay # https://stackoverflow.com/questions/12505047/in-python-why-doesnt-an-import-in-an-exec-in-a-function-work
     # from https://data.sfgov.org/Housing-and-Buildings/Height-and-Bulk-Districts/tt4g-gzy9/data
 
     # project to state plane CA Zone 3 (meters)
@@ -61,7 +60,6 @@ def before (data, datadir):
     return data
 
 def after (data, datadir):
-    global np, FOOT_TO_METER, partial, tqdm
     # Take care of special height limits
     print('Handling special height limits')
     rh1 = data[data.zone.apply(lambda x: x.startswith('RH-1'))].index

--- a/src/zoning/hooks/sanjose.py
+++ b/src/zoning/hooks/sanjose.py
@@ -10,7 +10,6 @@ tqdm.pandas()
 
 # copy over the specified Planned Development density
 def after (data, datadir):
-    global ACRE_TO_HECTARE, readZippedShapefile, fastOverlay, np, FOOT_TO_METER, join, pd, gp
     data = data.to_crs(epsg=26943)
 
     pds = data[data.ZONINGABBR.apply(lambda a: '(PD)' in a)].index


### PR DESCRIPTION
Imports in an exec'd function get added to the the third argument
that you pass into exec, but when it looks for global variables
it looks in the second argument. So if you pass the same dict to
both arguments, then imported things will get added to the same place
that it looks for the imported modules in, so the extra `global`
are no longer needed.